### PR TITLE
Potential fix for code scanning alert no. 82: Code injection

### DIFF
--- a/buggy_python_code.py
+++ b/buggy_python_code.py
@@ -22,14 +22,22 @@ def print_nametag(format_string, person):
 
 
 def fetch_website(urllib_version, url):
-    # Import the requested version (2 or 3) of urllib
-    exec(f"import urllib{urllib_version} as urllib", globals())
+    # Map valid versions to the corresponding urllib module
+    urllib_modules = {
+        "2": __import__("urllib2"),
+        "3": __import__("urllib3")
+    }
+    
+    # Validate the urllib_version parameter
+    if urllib_version not in urllib_modules:
+        raise ValueError("Invalid urllib version. Please use '2' or '3'.")
+    
     # Fetch and print the requested URL
- 
+    urllib = urllib_modules[urllib_version]
     try: 
         http = urllib.PoolManager()
-    except:
-        print('Exception')
+    except Exception as e:
+        print(f'Exception: {e}')
 
 
 def load_yaml(filename):


### PR DESCRIPTION
Potential fix for [https://github.com/Thdno/PV080_buggy_code/security/code-scanning/82](https://github.com/Thdno/PV080_buggy_code/security/code-scanning/82)

To fix the issue, we should avoid using `exec` to dynamically import modules. Instead, we can use a safer approach by explicitly mapping user input to the corresponding module. For example, we can use a dictionary to map valid `urllib_version` values ("2" or "3") to the appropriate `urllib` module. This eliminates the need for `exec` and ensures that only valid versions are used.

Changes to be made:
1. Replace the `exec` statement with a dictionary-based mapping for `urllib_version`.
2. Validate the `urllib_version` parameter to ensure it is one of the allowed values ("2" or "3").
3. Raise an error or return a meaningful response if the `urllib_version` parameter is invalid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
